### PR TITLE
Added possible attack vector

### DIFF
--- a/EIPS/eip-draft_gas_stations_network.md
+++ b/EIPS/eip-draft_gas_stations_network.md
@@ -274,7 +274,16 @@ Removal of stale relays is trustless. RelayHub verifies whether the removed rela
 Transactions include a nonce. RelayHub maintains a nonce (counter) for each sender. Transactions with bad nonces get reverted by RelayHub. Each transaction can only be relayed once.
 
 ##### Attack: User does not execute the raw transaction received from the Relayer, therefore blocking the execution of all further transactions signed by this relayer
-?? 
+The user doesn't really have to execute the raw transaction. It's enough that the user can. The relationship between relay and sender is mutual distrust. The process described above incentivizes the relay to execute the transaction, so the user doesn't need to wait for actual mining to know that the transaction has been executed.
+
+Once relay returns the signed transaction, which should happen immediately, the relay is incentivized to also execute it on chain, so that it can advance its nonce and serve the next transaction. The user can (but doesn't have to) also execute the transaction. To understand why the attack isn't viable, consider the four possible scenarios after the signed transaction was returned to the sender:
+
+1. Relay executes the transaction, and the user doesn't. In this scenario the transaction is executed, so no problem. This is the case described in this attack.
+2. Relay doesn't execute the transaction, but the user does. Similarly to 1, the transaction is executed, so no problem.
+3. Both of them execute the transaction. The transactions are identical in the pending transactions pool, so the transaction gets executed once. No problem.
+4. None of them execute the transaction. In this case the transaction doesn't get executed, but the relay is stuck. It can't serve the next transaction with the next nonce, because its nonce hasn't been advanced on-chain. It also can't serve the next transaction with the current nonce, as this can be proven by the user, having two different transactions signed by the same relay, with the same nonce. The user could use this to take the relay's nonce. So the relay is stuck unless it executes the transaction.
+
+As this matrix shows, the relay is __always__ incentivized to execute the transaction, once it returned it to the user, in order to end up in #1 or #3, and avoid the risk of #4. It's just a way to commit the relay to do its work, without requiring the user to wait for on-chain confirmation.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-draft_gas_stations_network.md
+++ b/EIPS/eip-draft_gas_stations_network.md
@@ -273,6 +273,9 @@ Removal of stale relays is trustless. RelayHub verifies whether the removed rela
 ##### Attack: Attacker attempts to replay a relayed transaction.
 Transactions include a nonce. RelayHub maintains a nonce (counter) for each sender. Transactions with bad nonces get reverted by RelayHub. Each transaction can only be relayed once.
 
+##### Attack: User does not execute the raw transaction received from the Relayer, therefore blocking the execution of all further transactions signed by this relayer
+?? 
+
 ## Backwards Compatibility
 
 The gas stations network is implemented as smart contracts and external entities, and does not require any network changes.


### PR DESCRIPTION
Why don't the Relayers submit the transaction for execution and provide the rawTransaction and txHash so the users can track it and possibly resubmit it?
